### PR TITLE
Addresses minor prereq issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Here are some practical, related topics we will cover for each algorithm:
 - Software
 - Scalability
 
-Instructions for how to install the neccessary software for this tutorial is available [here](tutorial-installation.md).  Data for the tutorial can be downloaded by running `./data/get-data.sh`.
+Instructions for how to install the neccessary software for this tutorial is available [here](tutorial-installation.md).  Data for the tutorial can be downloaded by running `./data/get-data.sh` (requires **wget**).
 
 ## Dimensionality Issues
 Certain algorithms don't scale well when there are millions of features.  For example, decision trees require computing some sort of metric (to determine the splits) on all the feature values (or some fraction of the values as in Random Forest and Stochastic GBM).  Therefore, computation time is linear in the number of features.  Other algorithms, such as GLM, scale much better to high-dimensional (n << p) and wide data with appropriate regularization (e.g. Lasso, Elastic Net, Ridge).
@@ -65,7 +65,6 @@ For each algorithm, we will provide examples of open source R packages that impl
 
 ## Scalability
 We will address scalability issues inherent to the algorithm and discuss algorithmic or technological solutions to scalability concerns for "big data."
-
 
 # Resources
 

--- a/data/get-mnist.sh
+++ b/data/get-mnist.sh
@@ -6,6 +6,6 @@ wget https://h2o-public-test-data.s3.amazonaws.com/bigdata/laptop/mnist/test.csv
 gunzip train.csv.gz
 gunzip test.csv.gz
 
-mv train.csv mnist_train.cv
-mv test.csv mnist_test.cv
+mv train.csv mnist_train.csv
+mv test.csv mnist_test.csv
 

--- a/tutorial-installation.md
+++ b/tutorial-installation.md
@@ -42,7 +42,7 @@ pip3 install -U jupyter
 Install the IRkernel binary in R.  More info [here](https://irkernel.github.io/installation/).
 
 ```r
-install.packages(c('repr', 'pbdZMQ', 'devtools'))
+install.packages(c('repr', 'pbdZMQ', 'devtools'), repos = c(CRAN = "https://cran.rstudio.com"))
 library(devtools)
 devtools::install_github('IRkernel/IRdisplay')
 devtools::install_github('IRkernel/IRkernel')


### PR DESCRIPTION
- Notes the wget requirement for downloading data.
- Fixes the filename typo.
- Specifies the RStudio CRAN mirror which may help when installing the
  repr package.
